### PR TITLE
Removed the use of the VUPLEX_CCU scripting symbol

### DIFF
--- a/Assets/Vuplex/Ready Player Me/VuplexWebView.cs
+++ b/Assets/Vuplex/Ready Player Me/VuplexWebView.cs
@@ -1,5 +1,4 @@
-﻿#if VUPLEX_CCU
-using System;
+﻿using System;
 using System.Text;
 using UnityEngine;
 using Vuplex.WebView;
@@ -22,12 +21,12 @@ public class VuplexWebView
     public Action<string> OnAvatarUrlReceived;
     public Action OnPageLoadFinished;
     public Action OnPageLoadStarted;
-    
+
     public void Initialize(BaseWebViewPrefab prefab, UrlConfig urlConfig)
     {
         Web.SetCameraAndMicrophoneEnabled(true);
         webView = prefab;
-        
+
         // TODO this function will be added to WebView module in future update
         string url = GetUrlFromConfig(urlConfig);
         webView.InitialUrl = url;
@@ -41,7 +40,7 @@ public class VuplexWebView
             webView.WebView.LoadProgressChanged += OnLoadProgressChanged;
         };
     }
-    
+
     /// <summary>
     /// TODO this function will be added to WebView module in future update
     /// we can remove once update is released to reduce code duplication
@@ -109,7 +108,7 @@ public class VuplexWebView
                     else {
                         const json = parse(event);
                         const source = json.source;
-                    
+
                         if (source !== 'readyplayerme') {
                             return;
                         }
@@ -164,6 +163,5 @@ public class VuplexWebView
             Debug.Log($"OnMessageReceived: { args.Value }\nError Message: { e.Message }");
         }
     }
-    
+
 }
-#endif

--- a/Assets/Vuplex/Ready Player Me/VuplexWebViewTest.cs
+++ b/Assets/Vuplex/Ready Player Me/VuplexWebViewTest.cs
@@ -1,5 +1,4 @@
-﻿#if VUPLEX_CCU
-using UnityEngine;
+﻿using UnityEngine;
 using ReadyPlayerMe.AvatarLoader;
 using ReadyPlayerMe.WebView;
 using Vuplex.WebView;
@@ -12,7 +11,7 @@ public class VuplexWebViewTest : MonoBehaviour
     [SerializeField] private GameObject loading;
     [SerializeField] private BaseWebViewPrefab canvasWebView;
     [SerializeField] private UrlConfig urlConfig;
-    
+
     private CanvasGroup canvasGroup;
     private void Start()
     {
@@ -68,4 +67,3 @@ public class VuplexWebViewTest : MonoBehaviour
     }
 
 }
-#endif


### PR DESCRIPTION
Hi 👋🏻. I'm the founder and developer of Vuplex 3D WebView. The VUPLEX_CCU symbol was an implementation detail of how 3D WebView used Unity's [Conditional Compilation Utility library](https://github.com/Unity-Technologies/ConditionalCompilationUtility) (CCU). For the upcoming 3D WebView v4.4 release, I've updated how 3D WebView uses CCU so that it no longer adds the VUPLEX_CCU symbol and actually removes that symbol from the player settings if it exists. I just realized that this example project uses that VUPLEX_CCU symbol, so I'm submitting this PR to remove usage of it.

I also just realized that my text editor (VS Code) automatically removed some superfluous whitespace that was present in the two files I modified.
